### PR TITLE
android targetSDK 31 버전 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity 
+            android:name=".MainActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
targetSDK 31 부터 intent-filter를 사용하는 activity, service, receiver에 android:exported 속성이 필수로 들어가도록 요구됩니다.
이에 맞춰 activity에 android:exported 속성을 추가하였습니다.