### PR TITLE
feat: 안드로이드 버전 별 이미지 피커 사용을 위한 권한 분리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.classtinginc.image_picker">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+                     android:maxSdkVersion="32" />
+
+    <!-- 안드로이드 13(API 레벨 33) 이상 -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+
+    <!-- 안드로이드 14 이상 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <application
         android:allowBackup="true"
@@ -17,7 +24,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 13
         versionName "1.1.4"
 

--- a/library/src/main/java/com/classtinginc/image_picker/folders/LocalFoldersActivity.java
+++ b/library/src/main/java/com/classtinginc/image_picker/folders/LocalFoldersActivity.java
@@ -1,5 +1,8 @@
 package com.classtinginc.image_picker.folders;
 
+import static android.Manifest.permission.READ_MEDIA_IMAGES;
+import static android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED;
+
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -84,26 +87,47 @@ public class LocalFoldersActivity extends AppCompatActivity implements LocalFold
 
     @TargetApi(16)
     private void checkPermission() {
-        String permission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ?
-                Manifest.permission.READ_MEDIA_IMAGES: Manifest.permission.READ_EXTERNAL_STORAGE;
-
-        RxPermissions.getInstance(this)
-            .request(permission)
-            .subscribe(new Action1<Boolean>() {
-                @Override
-                public void call(Boolean granted) {
-                    if (granted) {
-                        presenter.showFolders(LocalFoldersActivity.this);
-                    } else {
-                        Toast.makeText(
-                                LocalFoldersActivity.this,
-                                TranslationUtils.gePermissionGuide(LocalFoldersActivity.this),
-                                Toast.LENGTH_SHORT
-                        ).show();
-                        finish();
+        // Permission request logic
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            RxPermissions.getInstance(this)
+                .request(READ_MEDIA_IMAGES, READ_MEDIA_VISUAL_USER_SELECTED)
+                .subscribe(new Action1<Boolean>() {
+                    @Override
+                    public void call(Boolean granted) {
+                        if (granted) {
+                            presenter.showFolders(LocalFoldersActivity.this);
+                        } else {
+                            Toast.makeText(
+                                    LocalFoldersActivity.this,
+                                    TranslationUtils.gePermissionGuide(LocalFoldersActivity.this),
+                                    Toast.LENGTH_SHORT
+                            ).show();
+                            finish();
+                        }
                     }
-                }
-            });
+                });
+        } else {
+            String permission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ?
+                READ_MEDIA_IMAGES: Manifest.permission.READ_EXTERNAL_STORAGE;
+
+            RxPermissions.getInstance(this)
+                .request(permission)
+                .subscribe(new Action1<Boolean>() {
+                    @Override
+                    public void call(Boolean granted) {
+                        if (granted) {
+                            presenter.showFolders(LocalFoldersActivity.this);
+                        } else {
+                            Toast.makeText(
+                                    LocalFoldersActivity.this,
+                                    TranslationUtils.gePermissionGuide(LocalFoldersActivity.this),
+                                    Toast.LENGTH_SHORT
+                            ).show();
+                            finish();
+                        }
+                    }
+                });
+        }
     }
 
     @Override


### PR DESCRIPTION
참고
https://developer.android.com/about/versions/14/changes/partial-photo-video-access?hl=ko

안드로이드 14, 13, 12 이하로 분리하여 권한을 요청하도록 변경하였습니다.
매니페스트는 RN 프로젝트와 동일하게 변경했습니다.