### PR TITLE
GSON 활용을 위해 사용되던 Expose 어노테이션 제거

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -32,6 +32,5 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.9.0'
 
     implementation 'io.reactivex:rxandroid:1.0.1'
-    implementation 'com.tbruyelle.rxpermissions:rxpermissions:0.7.0@aar'
     implementation 'com.google.code.gson:gson:2.8.1'
 }

--- a/library/src/main/java/com/classtinginc/image_picker/folders/LocalFoldersActivity.java
+++ b/library/src/main/java/com/classtinginc/image_picker/folders/LocalFoldersActivity.java
@@ -108,7 +108,13 @@ public class LocalFoldersActivity extends AppCompatActivity implements LocalFold
         super.onActivityResult(requestCode, resultCode, data);
 
         if (resultCode == Activity.RESULT_OK && data != null && data.hasExtra(Extra.DATA)) {
+            Bundle extras = data.getExtras();
+            for (String key : extras.keySet()) {
+                Log.d("CTImagePicker", "extra data Key: " + key + ", Value: " + extras.get(key));
+            }
+
             setResult(Activity.RESULT_OK, data);
+
             finish();
         }
     }

--- a/library/src/main/java/com/classtinginc/image_picker/images/ImagePickerPresenter.java
+++ b/library/src/main/java/com/classtinginc/image_picker/images/ImagePickerPresenter.java
@@ -151,7 +151,7 @@ class ImagePickerPresenter {
                 Log.i("Classting:::", String.valueOf(ex));
             }
 
-            Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+            Gson gson = new GsonBuilder().create();
             view.done(gson.toJson(selectedImages));
         }
     }
@@ -167,7 +167,7 @@ class ImagePickerPresenter {
                 Log.i("Classting:::", String.valueOf(ex));
             }
 
-            Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+            Gson gson = new GsonBuilder().create();
             view.done(gson.toJson(selectedImages));
         }
     }

--- a/library/src/main/java/com/classtinginc/image_picker/models/Image.java
+++ b/library/src/main/java/com/classtinginc/image_picker/models/Image.java
@@ -3,8 +3,6 @@ package com.classtinginc.image_picker.models;
 import android.net.Uri;
 import android.webkit.MimeTypeMap;
 
-import com.google.gson.annotations.Expose;
-
 import java.io.File;
 import java.io.Serializable;
 
@@ -14,10 +12,7 @@ import java.io.Serializable;
 
 public class Image implements Serializable {
 
-    @Expose
     private String thumbId;
-
-    @Expose
     private String thumbPath;
     private String thumbsImageID;
     private int selectedIndex = -1;


### PR DESCRIPTION
RN 프로젝트를 안드로이드 14 로 업데이트 이후 Expose 어노테이션이 붙은 Attribute 가 직렬화되지 않는 문제가 발생하여 Expose 어노테이션을 제거하고 모든 Attribute 가 직렬화 되도록 하였습니다.

이전 PR에서 RxPermissions 을 사용한 권한 요청 부분을 제거하였는데 의존성은 남아 있어 이번 PR에 의존성 제거 커밋을 추가하였습니다.

LocalFolderActivity 에서 반환되는 data 값을 확인하기 위해 로그를 추가하였습니다.